### PR TITLE
Add launch test without hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@ Test utilities used across different PILZ ROS packages.
 ## Package `pilz_test_facility`
 [pilz_test_facility](pilz_test_facility/README.md) contains the Python and C++ API's for
 programmatically controlling the PILZ robot test facility via test.
+
+## Package `psen_scan_v2_prerelease`
+This package contains prerelease tests for the psen_scan_v2 package.

--- a/psen_scan_v2_prerelease/CMakeLists.txt
+++ b/psen_scan_v2_prerelease/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(psen_scan_v2_prerelease)
+
+find_package(catkin REQUIRED)
+
+###################################
+## catkin specific configuration ##
+###################################
+catkin_package()
+
+#############
+## Testing ##
+#############
+if (CATKIN_ENABLE_TESTING)
+  find_package(psen_scan_v2 REQUIRED)
+  find_package(rosnode REQUIRED)
+  find_package(rospy REQUIRED)
+  find_package(rostest REQUIRED)
+
+  add_rostest(test/integrationtest_ros_scanner_launch.test)
+endif()

--- a/psen_scan_v2_prerelease/README.md
+++ b/psen_scan_v2_prerelease/README.md
@@ -1,0 +1,2 @@
+# Prerelease tests for psen_scan_v2
+This package contains prerelease tests for the psen_scan_v2 package.

--- a/psen_scan_v2_prerelease/package.xml
+++ b/psen_scan_v2_prerelease/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>psen_scan_v2_prerelease</name>
+  <version>0.0.0</version>
+  <description>Prerelease tests for the psen_scan_v2 package</description>
+
+  <maintainer email="a.gutenkunst@pilz.de">Alexander Gutenkunst</maintainer>
+  <maintainer email="c.doehn@pilz.de">Christian Döhn</maintainer>
+  <maintainer email="c.henkel@pilz.de">Christian Henkel</maintainer>
+  <maintainer email="i.martini@pilz.de">Immanuel Martini</maintainer>
+  <maintainer email="r.feistenauer@pilz.de">Richard Feistenauer</maintainer>
+
+  <license>LGPLv3</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <test_depend>psen_scan_v2</test_depend>
+  <test_depend>roslaunch</test_depend>
+  <test_depend>rosnode</test_depend>
+  <test_depend>rospy</test_depend>
+  <test_depend>rostest</test_depend>
+  <test_depend>rosunit</test_depend>
+
+</package>

--- a/psen_scan_v2_prerelease/test/integrationtest_ros_scanner_launch.py
+++ b/psen_scan_v2_prerelease/test/integrationtest_ros_scanner_launch.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+import unittest
+import rosnode
+import rospy
+
+class TestStartup(unittest.TestCase):
+    def test_startup(self):
+        i = 0
+        expectedNode = '/laser_scanner'
+        while not expectedNode in rosnode.get_node_names():
+            rospy.sleep(rospy.Duration(0.5))
+            self.assertLess(i, 10, msg="node did not come up in the expected time") # wait 5s max
+            i += 1
+
+if __name__ == '__main__':
+    import rostest
+    rospy.init_node('test_ros_scanner_launch')
+    rostest.rosrun('psen_scan_v2_prerelease', 'test_startup', TestStartup)

--- a/psen_scan_v2_prerelease/test/integrationtest_ros_scanner_launch.test
+++ b/psen_scan_v2_prerelease/test/integrationtest_ros_scanner_launch.test
@@ -1,0 +1,24 @@
+<!--
+Copyright (c) 2020-2021 Pilz GmbH & Co. KG
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+<launch>
+
+  <include file="$(find psen_scan_v2)/launch/psen_scan_v2.launch">
+    <param name="sensor_ip" value="127.0.0.1" />
+  </include>
+  <test test-name="integrationtest_ros_scanner_launch" pkg="psen_scan_v2_prerelease" type="integrationtest_ros_scanner_launch.py"/>
+
+</launch>


### PR DESCRIPTION
## Description

These changes allow the maintainer of psen_scan_v2 to set up a prerelease test of the scanner startup.

### Things to add, update or check by the maintainers before this PR can be merged.

* [ ] Public api function documentation
* [ ] Architecture documentation reflects actual code structure
* [ ] [Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)
* [ ] Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)
* [ ] Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))
* [ ] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
* [ ] CHANGELOG.rst updated
* [ ] Copyright headers
* [ ] Examples

### Review Checklist
* [ ] Soft- and hardware architecture (diagrams and description)
* [ ] Test review (test plan and individual test cases)
* [ ] Documentation describes purpose of file(s) and responsibilities
* [ ] Code (coding rules, style guide)

### Release planning (please answer)
* [ ] When is the new feature released?
* [ ] Which dependent packages do have to be released simultaneously?
